### PR TITLE
Hotfix/removing switch case

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
+    "linebreak-style": "off",
+    "no-console": "off",
   },
 };

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+
 import Register from './core/models';
 
 const api = express();

--- a/src/core/commands/index.js
+++ b/src/core/commands/index.js
@@ -1,3 +1,9 @@
-export { default as save } from './save';
-export { default as help } from './help';
-export { default as remove } from './remove';
+import save from './save';
+import help from './help';
+import remove from './remove';
+
+export default {
+  save,
+  help,
+  remove,
+};

--- a/src/core/commandsObject.js
+++ b/src/core/commandsObject.js
@@ -1,0 +1,7 @@
+import { save, help, remove } from './commands';
+
+export default (params) => ({
+  help: help(params),
+  save: save(params),
+  remove: remove(params),
+});

--- a/src/core/commandsObject.js
+++ b/src/core/commandsObject.js
@@ -1,7 +1,0 @@
-import { save, help, remove } from './commands';
-
-export default (params) => ({
-  help: help(params),
-  save: save(params),
-  remove: remove(params),
-});

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,5 +1,6 @@
 import Discord from 'discord.js';
-import commands from './commandsObject'
+
+import commands from './commands';
 
 export default class Bot {
   constructor({
@@ -26,7 +27,9 @@ export default class Bot {
         .shift()
         .toLowerCase();
 
-      return commands({ message, prefix: this.prefix})[command || 'help'];
+      const params = { message, prefix: this.prefix };
+
+      commands[command || 'help'](params);
     } catch (e) {
       console.log(e);
     }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,5 +1,5 @@
 import Discord from 'discord.js';
-import { save, help, remove } from './commands';
+import commands from './commandsObject'
 
 export default class Bot {
   constructor({
@@ -26,22 +26,7 @@ export default class Bot {
         .shift()
         .toLowerCase();
 
-      if (args.length === 0) {
-        help({ message, prefix: this.prefix });
-      } else {
-        switch (command) {
-          case 'help':
-            help({ message, prefix: this.prefix });
-            break;
-          case 'save':
-            save({ message });
-            break;
-          case 'remove':
-            remove({ message });
-          default:
-            break;
-        }
-      }
+      return commands({ message, prefix: this.prefix})[command || 'help'];
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
**What I did**
Edited the src\core\commands\index.js file to export an object with the commands

Made some changes in the src\core\index.js file:
- Removed the whole if/else with the switch/case
- Created a variable called "params" tu receive the message and prefix
- Added the line: `commands[command || 'help'](params);` Which will get the commando (or the help, substituting the if/else logic) and send the params (even though we might be sending unecessairy params, the functions will only get what they need, since they're using destructuring)
